### PR TITLE
Add endpoint to fetch project assignment candidates

### DIFF
--- a/src/SkillBridge/Controllers/UserProfileController.cs
+++ b/src/SkillBridge/Controllers/UserProfileController.cs
@@ -74,5 +74,21 @@ namespace SkillBridge.Controllers
 
             return NoContent();
         }
+        /// <summary>
+        /// Gets all user candidates assigned to a given project assignment.
+        /// </summary>
+        /// <param name="projectId">The ID of the project assignment.</param>
+        /// <returns>
+        /// A list of user profiles assigned to the project.
+        [Authorize(Policy = "Company")]
+        [HttpGet("assignment/{projectId}/candidates")]
+        [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetAssigmnentCandidatesAsync(Guid projectId)
+        {
+            var task = await _userProfileService.GetByAssigmentId(projectId);
+            return Ok(task);
+        }
     }
 }

--- a/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
@@ -10,5 +10,7 @@ namespace SkillBridge.Services.UserProfile
         Task<UserProfileResponse> GetByIdAsync(string? userId);
         Task<UserProfileResponse> GetMyProfileAsync(string? userId);
         Task<UserProfileResponse> UpdateAsync(UpdateUserProfileRequest request,string? userId);
+        Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid id);
+
     }
 }

--- a/src/SkillBridge/Services/UserProfile/UserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/UserProfileService.cs
@@ -163,5 +163,13 @@ namespace SkillBridge.Services.UserProfile
 
             return _mapper.Map<UserProfileResponse>(userProfile);
         }
+
+        public async Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid projectId)
+        {
+            var candidates = await _dbContext.UserProjectAssignments.Include(x=>x.UserProfile).Where(upa => upa.ProjectAssignmentId == projectId).Select(x => x.UserProfile)
+                .ToListAsync();
+
+            return candidates;
+        }
     }
 }


### PR DESCRIPTION
Introduces a new API endpoint in UserProfileController to retrieve user profiles assigned to a specific project assignment. Adds corresponding service method in IUserProfileService and implements it in UserProfileService.