### PR TITLE
Make UserProfile file fields nullable

### DIFF
--- a/src/SkillBridge/Data/Migrations/20250904161908_UpdateUserProfileEntity.Designer.cs
+++ b/src/SkillBridge/Data/Migrations/20250904161908_UpdateUserProfileEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SkillBridge.Data;
@@ -11,9 +12,11 @@ using SkillBridge.Data;
 namespace SkillBridge.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904161908_UpdateUserProfileEntity")]
+    partial class UpdateUserProfileEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SkillBridge/Data/Migrations/20250904161908_UpdateUserProfileEntity.cs
+++ b/src/SkillBridge/Data/Migrations/20250904161908_UpdateUserProfileEntity.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SkillBridge.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateUserProfileEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "profile_picture",
+                table: "user_profiles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "github_connection",
+                table: "user_profiles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "cv_upload",
+                table: "user_profiles",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "profile_picture",
+                table: "user_profiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "github_connection",
+                table: "user_profiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "cv_upload",
+                table: "user_profiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/SkillBridge/Models/Entities/UserProfile.cs
+++ b/src/SkillBridge/Models/Entities/UserProfile.cs
@@ -27,8 +27,8 @@ public class UserProfile
     /// </summary>
     public ICollection<UserProjectAssignment> UserProjectAssignments { get; set; } = new List<UserProjectAssignment>();
 
-    public string ProfilePicture { get; set; } = string.Empty;
+    public string? ProfilePicture { get; set; }
 
-    public string CVUpload { get; set; } = string.Empty;    
-    public string GitHubConnection { get; set; } = string.Empty;
+    public string? CVUpload { get; set; }    
+    public string? GitHubConnection { get; set; }
 }


### PR DESCRIPTION
Changed ProfilePicture, CVUpload, and GitHubConnection properties in UserProfile to nullable strings. Updated the EF migration and model snapshot to reflect these fields as optional in the database schema.