### PR TITLE
Refactor user profile file uploads to separate endpoints

### DIFF
--- a/src/SkillBridge/Controllers/UserProfileController.cs
+++ b/src/SkillBridge/Controllers/UserProfileController.cs
@@ -52,11 +52,36 @@ namespace SkillBridge.Controllers
         [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> Update([FromRoute] string? userId,[FromForm] UpdateUserProfileRequest request)
+        public async Task<IActionResult> Update([FromRoute] string? userId,[FromBody] UpdateUserProfileRequest request)
         {
             var userProfile = await _userProfileService.UpdateAsync(request, userId);
 
             return Ok(userProfile);
         }
+
+
+
+        [Authorize(Policy = "Candidate")]
+        [HttpPatch("{userId?}/cv")]
+        [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CVUploadAsync([FromRoute] string? userId, [FromForm] CVUploadRequest request)
+        {
+            var userProfile = await _userProfileService.UpdateCVUpload(request, userId);
+            return Ok(userProfile);
+        }
+
+        [Authorize(Policy = "Candidate")]
+        [HttpPatch("{userId?}/profile-picture")]
+        [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> ProfilePictureAsync([FromRoute] string? userId, [FromForm] ProfilePictureRequest request)
+        {
+            var userProfile = await _userProfileService.UpdateProfilePicture(request, userId);
+            return Ok(userProfile);
+        }
+
     }
 }

--- a/src/SkillBridge/Infrastructure/Validation/Validators/UpdateUserProfileRequestValidator.cs
+++ b/src/SkillBridge/Infrastructure/Validation/Validators/UpdateUserProfileRequestValidator.cs
@@ -30,29 +30,29 @@ namespace SkillBridge.Infrastructure.Validation.Validators
         /// </summary>
         public UserProfileRequestValidator()
         {
-            // Profile picture (optional)
-            When(x => x.ProfilePicture != null, () =>
-            {
-                RuleFor(x => x.ProfilePicture!)
-                    .Must(f => f.Length <= ValidationConstants.UserProfile.ProfilePictureMaxBytes)
-                    .WithMessage($"Profile picture must be ≤ {BytesToMb(ValidationConstants.UserProfile.ProfilePictureMaxBytes)} MB.");
+            //// Profile picture (optional)
+            //When(x => x.ProfilePicture != null, () =>
+            //{
+            //    RuleFor(x => x.ProfilePicture!)
+            //        .Must(f => f.Length <= ValidationConstants.UserProfile.ProfilePictureMaxBytes)
+            //        .WithMessage($"Profile picture must be ≤ {BytesToMb(ValidationConstants.UserProfile.ProfilePictureMaxBytes)} MB.");
 
-                RuleFor(x => x.ProfilePicture!)
-                    .Must(f => AllowedImageContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
-                    .WithMessage($"Profile picture must be one of: {string.Join(", ", AllowedImageContentTypes)}.");
-            });
+            //    RuleFor(x => x.ProfilePicture!)
+            //        .Must(f => AllowedImageContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
+            //        .WithMessage($"Profile picture must be one of: {string.Join(", ", AllowedImageContentTypes)}.");
+            //});
 
-            // CV (optional)
-            When(x => x.CVUpload != null, () =>
-            {
-                RuleFor(x => x.CVUpload!)
-                    .Must(f => f.Length <= ValidationConstants.UserProfile.CvMaxBytes)
-                    .WithMessage($"CV must be ≤ {BytesToMb(ValidationConstants.UserProfile.CvMaxBytes)} MB.");
+            //// CV (optional)
+            //When(x => x.CVUpload != null, () =>
+            //{
+            //    RuleFor(x => x.CVUpload!)
+            //        .Must(f => f.Length <= ValidationConstants.UserProfile.CvMaxBytes)
+            //        .WithMessage($"CV must be ≤ {BytesToMb(ValidationConstants.UserProfile.CvMaxBytes)} MB.");
 
-                RuleFor(x => x.CVUpload!)
-                    .Must(f => AllowedCvContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
-                    .WithMessage($"CV must be one of: {string.Join(", ", AllowedCvContentTypes)}.");
-            });
+            //    RuleFor(x => x.CVUpload!)
+            //        .Must(f => AllowedCvContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
+            //        .WithMessage($"CV must be one of: {string.Join(", ", AllowedCvContentTypes)}.");
+            //});
 
             // GitHubConnection (optional)
             When(x => !string.IsNullOrWhiteSpace(x.GitHubConnection), () =>

--- a/src/SkillBridge/Infrastructure/Validation/Validators/UpdateUserProfileRequestValidator.cs
+++ b/src/SkillBridge/Infrastructure/Validation/Validators/UpdateUserProfileRequestValidator.cs
@@ -30,30 +30,6 @@ namespace SkillBridge.Infrastructure.Validation.Validators
         /// </summary>
         public UserProfileRequestValidator()
         {
-            //// Profile picture (optional)
-            //When(x => x.ProfilePicture != null, () =>
-            //{
-            //    RuleFor(x => x.ProfilePicture!)
-            //        .Must(f => f.Length <= ValidationConstants.UserProfile.ProfilePictureMaxBytes)
-            //        .WithMessage($"Profile picture must be ≤ {BytesToMb(ValidationConstants.UserProfile.ProfilePictureMaxBytes)} MB.");
-
-            //    RuleFor(x => x.ProfilePicture!)
-            //        .Must(f => AllowedImageContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
-            //        .WithMessage($"Profile picture must be one of: {string.Join(", ", AllowedImageContentTypes)}.");
-            //});
-
-            //// CV (optional)
-            //When(x => x.CVUpload != null, () =>
-            //{
-            //    RuleFor(x => x.CVUpload!)
-            //        .Must(f => f.Length <= ValidationConstants.UserProfile.CvMaxBytes)
-            //        .WithMessage($"CV must be ≤ {BytesToMb(ValidationConstants.UserProfile.CvMaxBytes)} MB.");
-
-            //    RuleFor(x => x.CVUpload!)
-            //        .Must(f => AllowedCvContentTypes.Contains(f.ContentType, StringComparer.OrdinalIgnoreCase))
-            //        .WithMessage($"CV must be one of: {string.Join(", ", AllowedCvContentTypes)}.");
-            //});
-
             // GitHubConnection (optional)
             When(x => !string.IsNullOrWhiteSpace(x.GitHubConnection), () =>
             {

--- a/src/SkillBridge/Models/Request/CVUploadRequest.cs
+++ b/src/SkillBridge/Models/Request/CVUploadRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace SkillBridge.Models.Request
+{
+    public class CVUploadRequest
+    {
+        public IFormFile? CVUpload { get; set; }
+    }
+}

--- a/src/SkillBridge/Models/Request/ProfilePictureRequest.cs
+++ b/src/SkillBridge/Models/Request/ProfilePictureRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace SkillBridge.Models.Request
+{
+    public class ProfilePictureRequest
+    {
+        public IFormFile? ProfilePicture { get; set; }
+    }
+}

--- a/src/SkillBridge/Models/Request/UpdateUserProfileRequest.cs
+++ b/src/SkillBridge/Models/Request/UpdateUserProfileRequest.cs
@@ -2,10 +2,6 @@
 {
     public class UpdateUserProfileRequest
     {
-        public IFormFile? ProfilePicture { get; set; } // Will also mirror to Auth0 "picture"
-
-        // App-owned (your DB)
-        public IFormFile? CVUpload { get; set; }
         public string? GitHubConnection { get; set; }
     }
 }

--- a/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
@@ -9,6 +9,7 @@ namespace SkillBridge.Services.UserProfile
         Task<UserProfileResponse> GetAsync(string? userId);
         Task<UserProfileResponse> UpdateAsync(UpdateUserProfileRequest request,string? userId);
         Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid id);
-
+        Task<UserProfileResponse> UpdateProfilePicture(ProfilePictureRequest request, string? userId);
+        Task<UserProfileResponse> UpdateCVUpload(CVUploadRequest request, string? userId);
     }
 }

--- a/src/SkillBridge/Services/UserProfile/UserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/UserProfileService.cs
@@ -55,8 +55,7 @@ namespace SkillBridge.Services.UserProfile
                 throw new EntityNotFoundException("Profile", $"for user {auth0UserId}",
                     $"No profile found for user ID {auth0UserId}");
             }
-            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
-            _logger.LogInformation("Profile found: {ProfileName}", username);
+            _logger.LogInformation("Profile with Id found: {ProfileId}", userProfile.Id);
 
             var response = _mapper.Map<UserProfileResponse>(userProfile);
 
@@ -81,28 +80,6 @@ namespace SkillBridge.Services.UserProfile
                 throw new EntityNotFoundException(nameof(Models.Entities.UserProfile), auth0UserId);
             }
 
-            // Update files and images
-
-            //if (request.CVUpload != null)
-            //{
-            //    if (!string.IsNullOrEmpty(userProfile.CVUpload))
-            //    {
-            //        await _fileUploader.DeleteFileAsync(userProfile.CVUpload, Models.Enums.FileType.CV);
-            //    }
-
-            //    userProfile.CVUpload = await _fileUploader.UploadFileAsync(request.CVUpload, Models.Enums.FileType.CV);
-            //}
-
-            //if (request.ProfilePicture != null)
-            //{
-            //    if (!string.IsNullOrEmpty(userProfile.ProfilePicture))
-            //    {
-            //        await _fileUploader.DeleteFileAsync(userProfile.ProfilePicture, Models.Enums.FileType.Image);
-            //    }
-
-            //    userProfile.ProfilePicture = await _fileUploader.UploadFileAsync(request.ProfilePicture, Models.Enums.FileType.Image);
-            //}
-
             if (request.GitHubConnection != null)
             {
                 userProfile.GitHubConnection = request.GitHubConnection;
@@ -113,9 +90,7 @@ namespace SkillBridge.Services.UserProfile
             _dbContext.UserProfiles.Update(userProfile);
             await _dbContext.SaveChangesAsync();
 
-            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
-
-            _logger.LogInformation("Profile updated successfully: {ProfileName}", username);
+            _logger.LogInformation("Profile updated successfully with Id: {ProfileId}", userProfile.Id);
 
             return _mapper.Map<UserProfileResponse>(userProfile);
         }
@@ -157,9 +132,7 @@ namespace SkillBridge.Services.UserProfile
             _dbContext.UserProfiles.Update(userProfile);
             await _dbContext.SaveChangesAsync();
 
-            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
-
-            _logger.LogInformation("Profile updated successfully: {ProfileName}", username);
+            _logger.LogInformation("Profile updated successfully with Id: {ProfileId}", userProfile.Id);
 
             return _mapper.Map<UserProfileResponse>(userProfile);
 
@@ -194,9 +167,7 @@ namespace SkillBridge.Services.UserProfile
             _dbContext.UserProfiles.Update(userProfile);
             await _dbContext.SaveChangesAsync();
 
-            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
-
-            _logger.LogInformation("Profile updated successfully: {ProfileName}", username);
+            _logger.LogInformation("Profile updated successfully with Id: {ProfileId}", userProfile.Id);
 
             return _mapper.Map<UserProfileResponse>(userProfile);
         }

--- a/src/SkillBridge/Services/UserProfile/UserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/UserProfileService.cs
@@ -82,26 +82,26 @@ namespace SkillBridge.Services.UserProfile
             }
 
             // Update files and images
-            
-            if (request.CVUpload != null)
-            {
-                if (!string.IsNullOrEmpty(userProfile.CVUpload))
-                {
-                    await _fileUploader.DeleteFileAsync(userProfile.CVUpload, Models.Enums.FileType.CV);
-                }
-                    
-                userProfile.CVUpload = await _fileUploader.UploadFileAsync(request.CVUpload, Models.Enums.FileType.CV);
-            }
-                
-            if (request.ProfilePicture != null)
-            {
-                if (!string.IsNullOrEmpty(userProfile.ProfilePicture))
-                {
-                    await _fileUploader.DeleteFileAsync(userProfile.ProfilePicture, Models.Enums.FileType.Image);
-                }
 
-                userProfile.ProfilePicture = await _fileUploader.UploadFileAsync(request.ProfilePicture, Models.Enums.FileType.Image);
-            }
+            //if (request.CVUpload != null)
+            //{
+            //    if (!string.IsNullOrEmpty(userProfile.CVUpload))
+            //    {
+            //        await _fileUploader.DeleteFileAsync(userProfile.CVUpload, Models.Enums.FileType.CV);
+            //    }
+
+            //    userProfile.CVUpload = await _fileUploader.UploadFileAsync(request.CVUpload, Models.Enums.FileType.CV);
+            //}
+
+            //if (request.ProfilePicture != null)
+            //{
+            //    if (!string.IsNullOrEmpty(userProfile.ProfilePicture))
+            //    {
+            //        await _fileUploader.DeleteFileAsync(userProfile.ProfilePicture, Models.Enums.FileType.Image);
+            //    }
+
+            //    userProfile.ProfilePicture = await _fileUploader.UploadFileAsync(request.ProfilePicture, Models.Enums.FileType.Image);
+            //}
 
             if (request.GitHubConnection != null)
             {
@@ -122,10 +122,85 @@ namespace SkillBridge.Services.UserProfile
 
         public async Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid projectId)
         {
-            var candidates = await _dbContext.UserProjectAssignments.Include(x=>x.UserProfile).Where(upa => upa.ProjectAssignmentId == projectId).Select(x => x.UserProfile)
+            var candidates = await _dbContext.UserProjectAssignments.Include(x => x.UserProfile).Where(upa => upa.ProjectAssignmentId == projectId).Select(x => x.UserProfile)
                 .ToListAsync();
 
             return candidates;
         }
+        public async Task<UserProfileResponse> UpdateCVUpload(CVUploadRequest request, string? userId = null)
+        {
+            //throw new NotImplementedException();
+            var auth0UserId = userId ?? _currentUser.GetUserId();
+            _logger.LogInformation("Updating profile with ID: {UserProfileId}", auth0UserId);
+
+            var userProfile = await _dbContext.UserProfiles.FindAsync(auth0UserId);
+
+            if (userProfile == null)
+            {
+                _logger.LogWarning("Profile with ID {ProfileId} not found", auth0UserId);
+                throw new EntityNotFoundException(nameof(Models.Entities.UserProfile), auth0UserId);
+            }
+
+
+            if (!string.IsNullOrEmpty(userProfile.CVUpload))
+            {
+                await _fileUploader.DeleteFileAsync(userProfile.CVUpload, Models.Enums.FileType.CV);
+                userProfile.CVUpload = null;
+            }
+            if (request.CVUpload != null)
+            {
+                userProfile.CVUpload = await _fileUploader.UploadFileAsync(request.CVUpload, Models.Enums.FileType.CV);
+            }
+
+            userProfile.UpdatedAt = DateTime.UtcNow;
+
+            _dbContext.UserProfiles.Update(userProfile);
+            await _dbContext.SaveChangesAsync();
+
+            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
+
+            _logger.LogInformation("Profile updated successfully: {ProfileName}", username);
+
+            return _mapper.Map<UserProfileResponse>(userProfile);
+
+        }
+
+        public async Task<UserProfileResponse> UpdateProfilePicture(ProfilePictureRequest request, string? userId = null)
+        {
+            var auth0UserId = userId ?? _currentUser.GetUserId();
+            _logger.LogInformation("Updating profile with ID: {UserProfileId}", auth0UserId);
+
+            var userProfile = await _dbContext.UserProfiles.FindAsync(auth0UserId);
+
+            if (userProfile == null)
+            {
+                _logger.LogWarning("Profile with ID {ProfileId} not found", auth0UserId);
+                throw new EntityNotFoundException(nameof(Models.Entities.UserProfile), auth0UserId);
+            }
+
+
+            if (!string.IsNullOrEmpty(userProfile.ProfilePicture))
+            {
+                await _fileUploader.DeleteFileAsync(userProfile.ProfilePicture, Models.Enums.FileType.Image);
+                userProfile.ProfilePicture = null;
+            }
+            if (request.ProfilePicture != null)
+            {
+                userProfile.ProfilePicture = await _fileUploader.UploadFileAsync(request.ProfilePicture, Models.Enums.FileType.Image);
+            }
+
+            userProfile.UpdatedAt = DateTime.UtcNow;
+
+            _dbContext.UserProfiles.Update(userProfile);
+            await _dbContext.SaveChangesAsync();
+
+            var username = (await _managementApiClient.Users.GetAsync(userProfile.Id)).UserName;
+
+            _logger.LogInformation("Profile updated successfully: {ProfileName}", username);
+
+            return _mapper.Map<UserProfileResponse>(userProfile);
+        }
+
+
     }
 }


### PR DESCRIPTION
Moved CV and profile picture uploads from UpdateUserProfileRequest to dedicated endpoints and request models. Updated controller, service interfaces, and implementations accordingly. Validation for file uploads in UpdateUserProfileRequestValidator is now commented out, reflecting the new separation of concerns.