### PR TITLE
Add project assignment search with specification pattern

### DIFF
--- a/src/SkillBridge/Controllers/ProjectAssignmentsController.cs
+++ b/src/SkillBridge/Controllers/ProjectAssignmentsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SkillBridge.Infrastructure.Exceptions;
 using SkillBridge.Models.Request;
 using SkillBridge.Models.Response;
+using SkillBridge.Models.Specifications;
 using SkillBridge.Services.ProjectAssignment;
 
 namespace SkillBridge.Controllers;
@@ -206,5 +207,28 @@ public class ProjectAssignmentsController : ControllerBase
     {
         var stats = await _projectAssignmentService.CompleteTaskAsync(projectId, taskId);
         return Ok(stats);
+    }
+
+    [HttpGet("search")]
+    // When pagination is implemented:
+    // public async Task<IPage<OrganizationDto>> SearchOrganizations(
+    public async Task<IEnumerable<ProjectAssignmentResponse>> Search(
+    [FromQuery] SearchProjectAssignmentRequest request,
+    int pageNumber = 1,
+    int pageSize = 10,
+    CancellationToken cancellationToken = default)
+    {
+        var specification = new ProjectAssignmentTitleSpecification(request.Title)
+            .And(new ProjectAssignmentLevelSpecification(request.Level))
+            .And(new ProjectAssignmentDeadlineAfterSpecification(request.DeadlineAfter))
+            .And(new ProjectAssignmentCompanyNameSpecification(request.CompanyName))
+            .And(new ProjectAssignmentCompanySectorSpecification(request.CompanySector))
+            .And(new ProjectAssignmentSkillsSpecification(request.ProjectSkills));
+
+        var result = await _projectAssignmentService.SearchAsync(
+            specification, pageNumber, pageSize, cancellationToken);
+
+        //return result.ToPage();
+        return result;
     }
 }

--- a/src/SkillBridge/Models/Request/SearchProjectAssignmentRequest.cs
+++ b/src/SkillBridge/Models/Request/SearchProjectAssignmentRequest.cs
@@ -1,0 +1,14 @@
+﻿using SkillBridge.Models.Enums;
+
+namespace SkillBridge.Models.Request
+{
+    public class SearchProjectAssignmentRequest
+    {
+        public string? Title { get; set; }
+        public ProjectAssignmentLevel? Level { get; set; }
+        public DateTime? DeadlineAfter { get; set; }
+        public string? CompanyName { get; set; }
+        public string? CompanySector { get; set; }
+        public ICollection<string> ProjectSkills { get; set; } = new List<string>();
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentCompanyNameSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentCompanyNameSpecification.cs
@@ -1,0 +1,18 @@
+﻿using SkillBridge.Models.Entities;
+using SkillBridge.Models.Enums;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentCompanyNameSpecification : Specification<ProjectAssignment>
+    {
+        private readonly string? companyName;
+
+        public ProjectAssignmentCompanyNameSpecification(string? companyName) => this.companyName = companyName;
+
+        protected override bool Include => companyName != null;
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.Company != null && ex.Company.Name == companyName;
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentCompanySectorSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentCompanySectorSpecification.cs
@@ -1,0 +1,17 @@
+﻿using SkillBridge.Models.Entities;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentCompanySectorSpecification : Specification<ProjectAssignment>
+    {
+        private readonly string? companySector;
+
+        public ProjectAssignmentCompanySectorSpecification(string? companySector) => this.companySector = companySector;
+
+        protected override bool Include => companySector != null;
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.Company != null && ex.Company.Sector == companySector;
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentDeadlineAfterSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentDeadlineAfterSpecification.cs
@@ -1,0 +1,17 @@
+﻿using SkillBridge.Models.Entities;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentDeadlineAfterSpecification : Specification<ProjectAssignment>
+    {
+        private readonly DateTime? deadLineAfter;
+
+        public ProjectAssignmentDeadlineAfterSpecification(DateTime? deadLineAfter) => this.deadLineAfter = deadLineAfter;
+
+        protected override bool Include => deadLineAfter != null;
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.Deadline > deadLineAfter;
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentLevelSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentLevelSpecification.cs
@@ -1,0 +1,18 @@
+﻿using SkillBridge.Models.Entities;
+using SkillBridge.Models.Enums;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentLevelSpecification : Specification<ProjectAssignment>
+    {
+        private readonly ProjectAssignmentLevel? level;
+
+        public ProjectAssignmentLevelSpecification(ProjectAssignmentLevel? level) => this.level = level;
+
+        protected override bool Include => level != null;
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.Level == level;
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentSkillsSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentSkillsSpecification.cs
@@ -1,0 +1,20 @@
+﻿using SkillBridge.Models.Entities;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentSkillsSpecification : Specification<ProjectAssignment>
+    {
+        private readonly ICollection<string> skills;
+
+        public ProjectAssignmentSkillsSpecification(ICollection<string> skills) => this.skills = skills;
+
+        protected override bool Include => skills != null && skills.Count != 0;
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.ProjectSkills != null && ex.ProjectSkills.Count != 0 && ex.ProjectSkills
+                .Where(x => x.Skill != null)
+                .Select(x => x.Skill!.Name)
+                .Any(skill => skills.Contains(skill));
+    }
+}

--- a/src/SkillBridge/Models/Specifications/ProjectAssignmentTitleSpecification.cs
+++ b/src/SkillBridge/Models/Specifications/ProjectAssignmentTitleSpecification.cs
@@ -1,0 +1,18 @@
+﻿using Auth0.ManagementApi.Models;
+using SkillBridge.Models.Entities;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    public class ProjectAssignmentTitleSpecification : Specification<ProjectAssignment>
+    {
+        private readonly string? title;
+
+        public ProjectAssignmentTitleSpecification(string? name) => this.title = name;
+
+        protected override bool Include => !string.IsNullOrWhiteSpace(title);
+
+        public override Expression<Func<ProjectAssignment, bool>> ToExpression()
+            => ex => ex.Title.ToLower().Contains(title!.ToLower());
+    }
+}

--- a/src/SkillBridge/Models/Specifications/Specification.cs
+++ b/src/SkillBridge/Models/Specifications/Specification.cs
@@ -1,0 +1,171 @@
+﻿using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+namespace SkillBridge.Models.Specifications
+{
+    /// <summary>
+    /// Represents the base specification pattern for evaluating conditions on entities of type <typeparamref name="T"/>.
+    /// Provides caching of compiled expressions and supports logical combination of specifications.
+    /// </summary>
+    /// <typeparam name="T">The type of entity to which the specification applies.</typeparam>
+    public abstract class Specification<T>
+    {
+        /// <summary>
+        /// Cache for compiled delegates, keyed by a unique cache key per specification.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, Func<T, bool>> DelegateCache
+            = new ConcurrentDictionary<string, Func<T, bool>>();
+
+        /// <summary>
+        /// Tracks the cache key components for uniquely identifying compiled delegates.
+        /// </summary>
+        private readonly List<string> _cacheKey;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Specification{T}"/> class.
+        /// </summary>
+        protected Specification()
+            => this._cacheKey = new List<string> { this.GetType().Name };
+
+        /// <summary>
+        /// Indicates whether this specification should be included in evaluation.
+        /// Defaults to <c>true</c>.
+        /// </summary>
+        protected virtual bool Include => true;
+
+        /// <summary>
+        /// Evaluates whether the given entity satisfies this specification.
+        /// Uses cached compiled delegates for performance optimization.
+        /// </summary>
+        /// <param name="value">The entity to evaluate.</param>
+        /// <returns><c>true</c> if the specification is satisfied; otherwise, <c>false</c>.</returns>
+        public virtual bool IsSatisfiedBy(T value)
+        {
+            if (!this.Include)
+            {
+                return true;
+            }
+
+            var func = DelegateCache.GetOrAdd(
+                string.Join(string.Empty, this._cacheKey),
+                _ => this.ToExpression().Compile());
+
+            return func(value);
+        }
+
+        /// <summary>
+        /// Combines this specification with another using a logical AND operator.
+        /// </summary>
+        /// <param name="specification">The other specification to combine with.</param>
+        /// <returns>A new specification representing the logical AND of both.</returns>
+        public Specification<T> And(Specification<T> specification)
+        {
+            if (!specification.Include)
+            {
+                return this;
+            }
+
+            this._cacheKey.Add($"{nameof(this.And)}{specification.GetType()}");
+
+            return new BinarySpecification(this, specification, true);
+        }
+
+        /// <summary>
+        /// Combines this specification with another using a logical OR operator.
+        /// </summary>
+        /// <param name="specification">The other specification to combine with.</param>
+        /// <returns>A new specification representing the logical OR of both.</returns>
+        public Specification<T> Or(Specification<T> specification)
+        {
+            if (!specification.Include)
+            {
+                return this;
+            }
+
+            this._cacheKey.Add($"{nameof(this.Or)}{specification.GetType()}");
+
+            return new BinarySpecification(this, specification, false);
+        }
+
+        /// <summary>
+        /// Converts the specification into an expression tree representing its predicate logic.
+        /// Must be implemented by concrete specifications.
+        /// </summary>
+        /// <returns>An expression tree defining the condition.</returns>
+        public abstract Expression<Func<T, bool>> ToExpression();
+
+        /// <summary>
+        /// Implicitly converts a specification to its underlying expression tree.
+        /// If <see cref="Include"/> is false, returns an expression that always evaluates to <c>true</c>.
+        /// </summary>
+        /// <param name="specification">The specification to convert.</param>
+        public static implicit operator Expression<Func<T, bool>>(Specification<T> specification)
+            => specification.Include
+                ? specification.ToExpression()
+                : value => true;
+
+        /// <summary>
+        /// Represents a specification that combines two other specifications with a logical operator (AND/OR).
+        /// </summary>
+        private class BinarySpecification : Specification<T>
+        {
+            private readonly Specification<T> left;
+            private readonly Specification<T> right;
+            private readonly bool andOperator;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="BinarySpecification"/> class.
+            /// </summary>
+            /// <param name="left">The left specification.</param>
+            /// <param name="right">The right specification.</param>
+            /// <param name="andOperator">If true, combines with AND; otherwise, with OR.</param>
+            public BinarySpecification(Specification<T> left, Specification<T> right, bool andOperator)
+            {
+                this.right = right;
+                this.left = left;
+                this.andOperator = andOperator;
+            }
+
+            /// <summary>
+            /// Builds the expression tree representing the logical combination of the left and right specifications.
+            /// </summary>
+            /// <returns>The combined expression tree.</returns>
+            public override Expression<Func<T, bool>> ToExpression()
+            {
+                Expression<Func<T, bool>> leftExpression = this.left;
+                Expression<Func<T, bool>> rightExpression = this.right;
+
+                Expression body = this.andOperator
+                    ? Expression.AndAlso(leftExpression.Body, rightExpression.Body)
+                    : Expression.OrElse(leftExpression.Body, rightExpression.Body);
+
+                var parameter = Expression.Parameter(typeof(T));
+                body = (BinaryExpression)new ParameterReplacer(parameter).Visit(body);
+
+                body = body ?? throw new InvalidOperationException("Binary expression cannot be null.");
+
+                return Expression.Lambda<Func<T, bool>>(body, parameter);
+            }
+        }
+
+        /// <summary>
+        /// Expression visitor used to replace parameters in expression trees with a single shared parameter.
+        /// Ensures compatibility when combining multiple specifications.
+        /// </summary>
+        private class ParameterReplacer : ExpressionVisitor
+        {
+            private readonly ParameterExpression parameter;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ParameterReplacer"/> class.
+            /// </summary>
+            /// <param name="parameter">The parameter expression to use as a replacement.</param>
+            internal ParameterReplacer(ParameterExpression parameter)
+                => this.parameter = parameter;
+
+            /// <inheritdoc />
+            protected override Expression VisitParameter(ParameterExpression node)
+                => base.VisitParameter(this.parameter);
+        }
+    }
+}

--- a/src/SkillBridge/Services/ProjectAssignment/IProjectAssignmentService.cs
+++ b/src/SkillBridge/Services/ProjectAssignment/IProjectAssignmentService.cs
@@ -1,5 +1,6 @@
 using SkillBridge.Models.Request;
 using SkillBridge.Models.Response;
+using SkillBridge.Models.Specifications;
 
 namespace SkillBridge.Services.ProjectAssignment;
 
@@ -16,7 +17,7 @@ public interface IProjectAssignmentService
     /// <returns>The created project assignment</returns>
     /// <exception cref="ArgumentException">Thrown when company or skills don't exist</exception>
     Task<ProjectAssignmentResponse> CreateAsync(Guid companyId, CreateProjectAssignmentRequest request);
-    
+
     /// <summary>
     /// Gets a project assignment by ID
     /// </summary>
@@ -24,20 +25,20 @@ public interface IProjectAssignmentService
     /// <returns>The project assignment if found</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment is not found</exception>
     Task<ProjectAssignmentResponse> GetByIdAsync(Guid id);
-    
+
     /// <summary>
     /// Gets all project assignments
     /// </summary>
     /// <returns>A list of all project assignments</returns>
     Task<IEnumerable<ProjectAssignmentResponse>> GetAllAsync();
-    
+
     /// <summary>
     /// Gets all project assignments for a specific company
     /// </summary>
     /// <param name="companyId">The company ID</param>
     /// <returns>A list of project assignments for the company</returns>
     Task<IEnumerable<ProjectAssignmentResponse>> GetByCompanyIdAsync(Guid companyId);
-    
+
     /// <summary>
     /// Updates a project assignment
     /// </summary>
@@ -47,14 +48,14 @@ public interface IProjectAssignmentService
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment is not found</exception>
     /// <exception cref="ArgumentException">Thrown when skills don't exist</exception>
     Task<ProjectAssignmentResponse> UpdateAsync(Guid id, UpdateProjectAssignmentRequest request);
-    
+
     /// <summary>
     /// Deletes a project assignment
     /// </summary>
     /// <param name="id">The project assignment ID</param>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment is not found</exception>
     Task DeleteAsync(Guid id);
-    
+
     /// <summary>
     /// Creates a new task for a project assignment
     /// </summary>
@@ -63,7 +64,7 @@ public interface IProjectAssignmentService
     /// <returns>The created task</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment is not found</exception>
     Task<AssignmentTaskResponse> CreateTaskAsync(Guid projectId, CreateAssignmentTaskRequest request);
-    
+
     /// <summary>
     /// Gets all tasks for a project assignment
     /// </summary>
@@ -71,7 +72,7 @@ public interface IProjectAssignmentService
     /// <returns>A list of tasks for the project assignment</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment is not found</exception>
     Task<IEnumerable<AssignmentTaskResponse>> GetTasksAsync(Guid projectId);
-    
+
     /// <summary>
     /// Gets a specific task from a project assignment
     /// </summary>
@@ -80,7 +81,7 @@ public interface IProjectAssignmentService
     /// <returns>The task if found</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment or task is not found</exception>
     Task<AssignmentTaskResponse> GetTaskByIdAsync(Guid projectId, Guid taskId);
-    
+
     /// <summary>
     /// Updates a specific task in a project assignment
     /// </summary>
@@ -90,7 +91,7 @@ public interface IProjectAssignmentService
     /// <returns>The updated task</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment or task is not found</exception>
     Task<AssignmentTaskResponse> UpdateTaskAsync(Guid projectId, Guid taskId, UpdateAssignmentTaskRequest request);
-    
+
     /// <summary>
     /// Deletes a specific task from a project assignment
     /// </summary>
@@ -107,4 +108,18 @@ public interface IProjectAssignmentService
     /// <returns>The completed/uncompleted task</returns>
     /// <exception cref="SkillBridge.Infrastructure.Exceptions.EntityNotFoundException">Thrown when project assignment or task is not found</exception>
     Task<AssignmentTaskResponse> CompleteTaskAsync(Guid projectId, Guid taskId);
+
+    /// <summary>
+    /// Searches project assignments using the provided specification with pagination
+    /// </summary>
+    /// <param name="specification">The filtering and search specification</param>
+    /// <param name="pageNumber">The page number for pagination</param>
+    /// <param name="pageSize">The page size for pagination</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>A paginated list of project assignments matching the specification</returns>
+    // Task<PagedList<ProjectAssignmentResponse>>
+    Task<IEnumerable<ProjectAssignmentResponse>> SearchAsync(Specification<Models.Entities.ProjectAssignment> specification,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default);
 }

--- a/src/SkillBridge/Services/ProjectAssignment/ProjectAssignmentService.cs
+++ b/src/SkillBridge/Services/ProjectAssignment/ProjectAssignmentService.cs
@@ -6,6 +6,7 @@ using SkillBridge.Infrastructure.Exceptions;
 using SkillBridge.Models.Entities;
 using SkillBridge.Models.Request;
 using SkillBridge.Models.Response;
+using SkillBridge.Models.Specifications;
 using SkillBridge.Services.Skill;
 
 namespace SkillBridge.Services.ProjectAssignment;
@@ -432,5 +433,41 @@ public class ProjectAssignmentService : IProjectAssignmentService
            taskId, projectId);
 
         return _mapper.Map<AssignmentTaskResponse>(task);
+    }
+
+    /// <summary>
+    /// Searches project assignments based on a specification with pagination
+    /// </summary>
+
+    // TODO: Implement pagination for search results AND in the Intreface IProjectAssignmentService
+    // public async Task<PagedList<ProjectAssignmentResponse>>
+    public async Task<IEnumerable<ProjectAssignmentResponse>> SearchAsync(Specification<Models.Entities.ProjectAssignment> specification,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.ProjectAssignments
+            .Include(p => p.Company)
+            .Include(p => p.ProjectSkills)
+                .ThenInclude(ps => ps.Skill)
+            .Where(specification);
+
+        /* var totalCount = await query.CountAsync(cancellationToken);
+
+         var data = await query
+             .Skip((pageNumber - 1) * pageSize)
+             .Take(pageSize)
+             .ToListAsync(cancellationToken);
+
+         var mapped = _mapper.Map<List<ProjectAssignmentResponse>>(data);
+
+         var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
+
+         return new PagedList<ProjectAssignmentResponse>(mapped, pageNumber, pageSize, totalPages, totalCount);*/
+
+        // Delete this when pagination is implemented
+        var results = await query.ToListAsync();
+        return results.Select(p => _mapper.Map<ProjectAssignmentResponse>(p));
+
     }
 }


### PR DESCRIPTION
Introduces a flexible search endpoint for project assignments using a specification pattern. Adds various specification classes for filtering by title, level, deadline, company name, sector, and required skills. Updates the controller and service interfaces to support paginated search, and implements the search logic in ProjectAssignmentService.