### PR TITLE
Add endpoint to fetch project assignment candidates

### DIFF
--- a/src/SkillBridge/Controllers/ProjectAssignmentsController.cs
+++ b/src/SkillBridge/Controllers/ProjectAssignmentsController.cs
@@ -6,6 +6,7 @@ using SkillBridge.Models.Request;
 using SkillBridge.Models.Response;
 using SkillBridge.Models.Specifications;
 using SkillBridge.Services.ProjectAssignment;
+using SkillBridge.Services.UserProfile;
 using System.ComponentModel.DataAnnotations;
 
 namespace SkillBridge.Controllers;
@@ -237,5 +238,22 @@ public class ProjectAssignmentsController : ControllerBase
 
         //return result.ToPage();
         return result;
+    }
+
+    /// <summary>
+    /// Gets all user candidates assigned to a given project assignment.
+    /// </summary>
+    /// <param name="projectId">The ID of the project assignment.</param>
+    /// <returns>
+    /// A list of user profiles assigned to the project.
+    [Authorize(Policy = "Company")]
+    [HttpGet("project-assignments/{projectId}/candidates")]
+    [ProducesResponseType(typeof(UserProfileResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAssigmnentCandidatesAsync(Guid projectId)
+    {
+        var task = await _projectAssignmentService.GetByAssigmentId(projectId);
+        return Ok(task);
     }
 }

--- a/src/SkillBridge/Services/ProjectAssignment/IProjectAssignmentService.cs
+++ b/src/SkillBridge/Services/ProjectAssignment/IProjectAssignmentService.cs
@@ -124,4 +124,6 @@ public interface IProjectAssignmentService
         int pageNumber,
         int pageSize,
         CancellationToken cancellationToken = default);
+
+    Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid id);
 }

--- a/src/SkillBridge/Services/ProjectAssignment/ProjectAssignmentService.cs
+++ b/src/SkillBridge/Services/ProjectAssignment/ProjectAssignmentService.cs
@@ -493,4 +493,11 @@ public class ProjectAssignmentService : IProjectAssignmentService
         return results.Select(p => _mapper.Map<ProjectAssignmentResponse>(p));
 
     }
+    public async Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid projectId)
+    {
+        var candidates = await _dbContext.UserProjectAssignments.Include(x => x.UserProfile).Where(upa => upa.ProjectAssignmentId == projectId).Select(x => x.UserProfile)
+            .ToListAsync();
+
+        return candidates;
+    }
 }

--- a/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/IUserProfileService.cs
@@ -8,7 +8,6 @@ namespace SkillBridge.Services.UserProfile
     {
         Task<UserProfileResponse> GetAsync(string? userId);
         Task<UserProfileResponse> UpdateAsync(UpdateUserProfileRequest request,string? userId);
-        Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid id);
         Task<UserProfileResponse> UpdateProfilePicture(ProfilePictureRequest request, string? userId);
         Task<UserProfileResponse> UpdateCVUpload(CVUploadRequest request, string? userId);
     }

--- a/src/SkillBridge/Services/UserProfile/UserProfileService.cs
+++ b/src/SkillBridge/Services/UserProfile/UserProfileService.cs
@@ -95,13 +95,6 @@ namespace SkillBridge.Services.UserProfile
             return _mapper.Map<UserProfileResponse>(userProfile);
         }
 
-        public async Task<List<Models.Entities.UserProfile>> GetByAssigmentId(Guid projectId)
-        {
-            var candidates = await _dbContext.UserProjectAssignments.Include(x => x.UserProfile).Where(upa => upa.ProjectAssignmentId == projectId).Select(x => x.UserProfile)
-                .ToListAsync();
-
-            return candidates;
-        }
         public async Task<UserProfileResponse> UpdateCVUpload(CVUploadRequest request, string? userId = null)
         {
             //throw new NotImplementedException();
@@ -171,7 +164,6 @@ namespace SkillBridge.Services.UserProfile
 
             return _mapper.Map<UserProfileResponse>(userProfile);
         }
-
-
     }
 }
+ 


### PR DESCRIPTION
Introduced a new API endpoint in ProjectAssignmentsController to retrieve user profiles assigned to a specific project assignment. The logic for fetching candidates was moved from UserProfileService to ProjectAssignmentService, and the corresponding interface methods were updated.